### PR TITLE
FEATURE: add capacity endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ signature.png
 log.txt
 tests/keys/*
 CLAUDE.md
+response_examples

--- a/ofsc/capacity.py
+++ b/ofsc/capacity.py
@@ -1,18 +1,75 @@
+from typing import Optional, Union, get_origin, get_args
 from urllib.parse import urljoin
+import inspect
 
 import requests
+from pydantic import BaseModel
 
-from ofsc.models import OFSApi
+from ofsc.models import CsvList, OFSApi
 
 from .common import OBJ_RESPONSE, wrap_return
-from .models import CapacityRequest, GetCapacityResponse
+from .models import CapacityRequest, GetCapacityResponse, GetQuotaRequest, GetQuotaResponse
+
+
+def _convert_model_to_api_params(model: BaseModel) -> dict:
+    """
+    Convert a Pydantic BaseModel instance to API-compatible parameters dictionary.
+    
+    This internal function uses inspection to automatically detect and convert:
+    - CsvList fields: Converts serialized CsvList objects (dict with 'value' key) to string values
+    - Boolean fields: Converts boolean values to lowercase strings for API compatibility
+    
+    :param model: Pydantic BaseModel instance to convert
+    :return: Dictionary with API-compatible parameter values
+    """
+    # Start with model dump, excluding None values
+    params = model.model_dump(exclude_none=True)
+    
+    # Use inspection to get field type annotations
+    model_fields = model.model_fields
+    
+    # Detect CsvList fields and convert them
+    for field_name, field_info in model_fields.items():
+        if field_name in params:
+            # Check if field type is CsvList or Optional[CsvList]
+            field_type = field_info.annotation
+            
+            # Handle Optional[CsvList] by checking Union args
+            actual_type = field_type
+            if get_origin(field_type) is Union:
+                # For Optional[Type], Union is (Type, NoneType)
+                union_args = get_args(field_type)
+                non_none_types = [arg for arg in union_args if arg is not type(None)]
+                if non_none_types:
+                    actual_type = non_none_types[0]
+            
+            # Convert CsvList fields
+            if actual_type is CsvList:
+                field_value = params[field_name]
+                if isinstance(field_value, dict) and 'value' in field_value:
+                    params[field_name] = field_value['value']
+            
+            # Convert boolean fields to lowercase strings
+            elif actual_type is bool or (get_origin(actual_type) is Union and bool in get_args(actual_type)):
+                field_value = params[field_name]
+                if isinstance(field_value, bool):
+                    params[field_name] = str(field_value).lower()
+    
+    return params
 
 
 class OFSCapacity(OFSApi):
     # OFSC Function Library
 
     @wrap_return(response_type=OBJ_RESPONSE, model=GetCapacityResponse)
-    def getAvailableCapacity(self, request: CapacityRequest):
+    def getAvailableCapacity(self, 
+                             dates: Union[list[str], CsvList, str],
+                             areas: Union[list[str], CsvList, str],
+                             categories: Optional[Union[list[str], CsvList, str]] = None,
+                             aggregateResults: Optional[bool] = None,
+                             availableTimeIntervals: str = "all",
+                             calendarTimeIntervals: str = "all",
+                             fields: Optional[list[str]] = None):
         """
         Get available capacity for a given resource or group of resources.
 
@@ -20,23 +77,87 @@ class OFSCapacity(OFSApi):
         for specified capacity areas and date ranges. The response includes metrics by area
         and optionally by category.
 
-        :param request: CapacityRequest object containing:
-            - areas: List of capacity area labels to query
-            - dates: List of dates in YYYY-MM-DD format
-            - categories: Optional list of capacity categories to filter by
-            - aggregateResults: Optional boolean to aggregate results
-            - availableTimeIntervals: Time interval specification (default: "all")
-            - calendarTimeIntervals: Calendar interval specification (default: "all")
-            - fields: Optional list of fields to include in response
+        :param dates: Required. List of dates in YYYY-MM-DD format, CsvList, or CSV string
+        :param areas: Required. List of capacity area labels, CsvList, or CSV string
+        :param categories: Optional. List of capacity categories, CsvList, or CSV string
+        :param aggregateResults: Optional. Boolean to aggregate results
+        :param availableTimeIntervals: Time interval specification (default: "all")
+        :param calendarTimeIntervals: Calendar interval specification (default: "all")
+        :param fields: Optional. List of fields to include in response
         :return: GetCapacityResponse instance containing capacity data with:
             - items: List of capacity data by date
             - areas: Capacity areas with calendar metrics and categories
             - calendar: Calendar time metrics (count arrays)
             - available: Available time metrics (when present)
         """
-        params = request.model_dump(exclude_none=True)
+        # Build CapacityRequest object from individual parameters
+        capacity_request = CapacityRequest(
+            dates=dates,
+            areas=areas,
+            categories=categories,
+            aggregateResults=aggregateResults,
+            availableTimeIntervals=availableTimeIntervals,
+            calendarTimeIntervals=calendarTimeIntervals,
+            fields=fields
+        )
+        
+        # Convert model to API-compatible parameters using internal converter
+        params = _convert_model_to_api_params(capacity_request)
+        
+        # Build URL and make request
         base_url = self.baseUrl or ""
         url = urljoin(base_url, "/rest/ofscCapacity/v1/capacity")
+        response = requests.get(
+            url,
+            headers=self.headers,
+            params=params,
+        )
+        return response
+
+    @wrap_return(response_type=OBJ_RESPONSE, model=GetQuotaResponse)
+    def getQuota(self, 
+                 dates: Union[list[str], CsvList, str],
+                 areas: Optional[Union[list[str], CsvList, str]] = None,
+                 categories: Optional[Union[list[str], CsvList, str]] = None,
+                 aggregateResults: Optional[bool] = None,
+                 categoryLevel: Optional[bool] = None,
+                 intervalLevel: Optional[bool] = None,
+                 returnStatuses: Optional[bool] = None,
+                 timeSlotLevel: Optional[bool] = None):
+        """
+        Get quota information for specified areas and dates.
+
+        This method retrieves quota information with flexible parameters that are
+        converted internally to a GetQuotaRequest object.
+
+        :param dates: Required. List of dates in YYYY-MM-DD format, CsvList, or CSV string
+        :param areas: Optional. List of capacity area labels, CsvList, or CSV string
+        :param categories: Optional. List of capacity categories, CsvList, or CSV string
+        :param aggregateResults: Optional. Boolean to aggregate results
+        :param categoryLevel: Optional. Boolean for category level reporting
+        :param intervalLevel: Optional. Boolean for interval level reporting
+        :param returnStatuses: Optional. Boolean for status return flag
+        :param timeSlotLevel: Optional. Boolean for time slot level reporting
+        :return: GetQuotaResponse instance containing quota data
+        """
+        # Build GetQuotaRequest object from individual parameters
+        quota_request = GetQuotaRequest(
+            dates=dates,
+            areas=areas,
+            categories=categories,
+            aggregateResults=aggregateResults,
+            categoryLevel=categoryLevel,
+            intervalLevel=intervalLevel,
+            returnStatuses=returnStatuses,
+            timeSlotLevel=timeSlotLevel
+        )
+        
+        # Convert model to API-compatible parameters using internal converter
+        params = _convert_model_to_api_params(quota_request)
+        
+        # Build URL and make request
+        base_url = self.baseUrl or ""
+        url = urljoin(base_url, "/rest/ofscCapacity/v2/quota")
         response = requests.get(
             url,
             headers=self.headers,

--- a/ofsc/capacity.py
+++ b/ofsc/capacity.py
@@ -1,0 +1,45 @@
+from urllib.parse import urljoin
+
+import requests
+
+from ofsc.models import OFSApi
+
+from .common import OBJ_RESPONSE, wrap_return
+from .models import CapacityRequest, GetCapacityResponse
+
+
+class OFSCapacity(OFSApi):
+    # OFSC Function Library
+
+    @wrap_return(response_type=OBJ_RESPONSE, model=GetCapacityResponse)
+    def getAvailableCapacity(self, request: CapacityRequest):
+        """
+        Get available capacity for a given resource or group of resources.
+
+        This method retrieves capacity information including calendar time and available time
+        for specified capacity areas and date ranges. The response includes metrics by area
+        and optionally by category.
+
+        :param request: CapacityRequest object containing:
+            - areas: List of capacity area labels to query
+            - dates: List of dates in YYYY-MM-DD format
+            - categories: Optional list of capacity categories to filter by
+            - aggregateResults: Optional boolean to aggregate results
+            - availableTimeIntervals: Time interval specification (default: "all")
+            - calendarTimeIntervals: Calendar interval specification (default: "all")
+            - fields: Optional list of fields to include in response
+        :return: GetCapacityResponse instance containing capacity data with:
+            - items: List of capacity data by date
+            - areas: Capacity areas with calendar metrics and categories
+            - calendar: Calendar time metrics (count arrays)
+            - available: Available time metrics (when present)
+        """
+        params = request.model_dump(exclude_none=True)
+        base_url = self.baseUrl or ""
+        url = urljoin(base_url, "/rest/ofscCapacity/v1/capacity")
+        response = requests.get(
+            url,
+            headers=self.headers,
+            params=params,
+        )
+        return response

--- a/ofsc/common.py
+++ b/ofsc/common.py
@@ -53,7 +53,7 @@ def wrap_return(*decorator_args, **decorator_kwargs):
                             data_response = response.json()
                             if config.auto_model and model is not None:
                                 # Remove the links unless there is a field called links in the model
-                                if not hasattr(model, "links"):
+                                if not hasattr(model, "links") and "links" in data_response:
                                     del data_response["links"]
                                 return model.model_validate(data_response)
                             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ofsc"
-version = "2.13.0"
+version = "2.14.0"
 description = "Python wrapper for Oracle Field Service API"
 authors = [{ name = "Borja Toron", email = "borja.toron@gmail.com" }]
 requires-python = "~=3.11"

--- a/tests/capacity/README.md
+++ b/tests/capacity/README.md
@@ -1,0 +1,125 @@
+# Capacity Module Test Suite
+
+This directory contains comprehensive tests for the OFSC Capacity module functionality.
+
+## Test Files Overview
+
+### Mocked Tests (Unit Tests)
+- **`test_capacity_mocked.py`**: Unit tests for the capacity module using mocked responses
+- **`test_quota_mocked.py`**: Quota-specific tests using real server response data captured in `real_responses.json`
+
+### Integration Tests (Real Server)
+- **`test_capacity_integration.py`**: Full integration tests for the capacity module against real OFSC server
+- **`test_quota_integration.py`**: Quota-specific integration tests against real OFSC server
+
+### Test Data
+- **`real_responses.json`**: Captured real server responses for consistent mocking
+
+## Test Coverage
+
+### Functions Tested
+- `getAvailableCapacity()` - Get available capacity for resources
+- `getQuota()` - Get quota information with flexible parameters
+
+### Models Tested
+- `CapacityRequest` - Request model for capacity queries
+- `GetCapacityResponse` - Response model for capacity data
+- `GetQuotaRequest` - Request model for quota queries with CsvList conversion
+- `GetQuotaResponse` - Response model for quota data
+- `QuotaAreaItem` - Individual quota area response model
+- `CsvList` - Utility model for comma-separated list handling
+
+### Test Scenarios
+
+#### Input Format Testing
+- List inputs: `["FLUSA", "CAUSA"]`
+- CSV string inputs: `"FLUSA,CAUSA"`
+- CsvList object inputs: `CsvList.from_list(["FLUSA", "CAUSA"])`
+- Mixed format inputs in same request
+
+#### Parameter Testing
+- Required parameters (dates)
+- Optional parameters (areas, categories, boolean flags)
+- Boolean to lowercase string conversion
+- Empty and None parameter handling
+
+#### Real Data Testing
+- Real capacity areas: FLUSA, CAUSA
+- Real capacity categories: EST, RES, COM
+- Current dates (today/tomorrow)
+- Multiple date ranges
+
+#### Response Validation
+- Model structure validation
+- Field type validation
+- Optional field handling
+- Extra field allowance
+
+## Running Tests
+
+### Run All Capacity Tests
+```bash
+uv run pytest tests/capacity/ -v
+```
+
+### Run Only Mocked Tests (Fast)
+```bash
+uv run pytest tests/capacity/test_*_mocked.py -v
+```
+
+### Run Only Integration Tests (Requires Credentials)
+```bash
+uv run pytest tests/capacity/test_*_integration.py -v -m integration
+```
+
+### Run Performance Tests (Slow)
+```bash
+uv run pytest tests/capacity/ -v -m slow
+```
+
+## Environment Variables Required for Integration Tests
+
+Integration tests require these environment variables in `.env`:
+- `OFSC_CLIENT_ID` - Your OFSC client ID
+- `OFSC_CLIENT_SECRET` - Your OFSC client secret  
+- `OFSC_COMPANY` - Your OFSC company name
+- `OFSC_ROOT` - Your OFSC root (optional)
+
+Integration tests will automatically skip if these are not provided.
+
+## Test Marks
+
+- `@pytest.mark.integration` - Tests that require real server connection
+- `@pytest.mark.slow` - Tests that may take longer to execute (performance tests)
+
+## Real Server Response Data
+
+The `real_responses.json` file contains actual server responses for these scenarios:
+1. **minimal_dates_only** - Request with only dates parameter
+2. **with_areas** - Request with specific areas
+3. **with_categories** - Request with areas and categories
+4. **with_boolean_flags** - Request with boolean parameters (aggregateResults, etc.)
+
+This data ensures mocked tests accurately reflect real server behavior.
+
+## Test Structure
+
+Each test file follows this pattern:
+- **Setup**: Fixtures for OFSC instance, test data, real areas/categories
+- **Model Tests**: Validation of Pydantic models with real data
+- **API Tests**: Function calls with various parameter combinations
+- **Integration Tests**: End-to-end testing with real server
+- **Performance Tests**: Load and timing tests for production readiness
+
+## Expected Test Results
+
+- **Mocked tests**: Should always pass (no external dependencies)
+- **Integration tests**: Will skip without credentials, pass with valid credentials
+- **Performance tests**: Should complete within reasonable time thresholds
+
+## Continuous Integration
+
+For CI/CD pipelines:
+1. Always run mocked tests (fast, no external dependencies)
+2. Run integration tests only when credentials are available
+3. Use performance tests for release validation

--- a/tests/capacity/__init__.py
+++ b/tests/capacity/__init__.py
@@ -1,0 +1,11 @@
+"""
+Test suite for OFSC Capacity module.
+
+This package contains comprehensive tests for the capacity functionality:
+- test_capacity_mocked.py: Unit tests with mocked responses
+- test_quota_mocked.py: Quota-specific tests with real server response data
+- test_quota_integration.py: Integration tests for quota API
+- test_capacity_integration.py: Integration tests for full capacity module
+
+Real server responses are captured in real_responses.json for consistent mocking.
+"""

--- a/tests/capacity/real_responses.json
+++ b/tests/capacity/real_responses.json
@@ -1,0 +1,229 @@
+{
+  "minimal_dates_only": {
+    "description": "Minimal request with only dates",
+    "request_params": {
+      "dates": [
+        "2025-06-25"
+      ]
+    },
+    "processed_params": {
+      "dates": "2025-06-25"
+    },
+    "status_code": 200,
+    "response_data": {
+      "items": [
+        {
+          "date": "2025-06-25",
+          "areas": [
+            {
+              "label": "routing_old",
+              "name": "Planning",
+              "maxAvailable": 47539,
+              "otherActivities": 0,
+              "quota": null,
+              "quotaPercent": null,
+              "minQuota": 0,
+              "used": 0,
+              "bookedActivities": 0
+            },
+            {
+              "label": "FLUSA",
+              "name": "FL, USA",
+              "maxAvailable": 14158,
+              "otherActivities": 971,
+              "quota": null,
+              "quotaPercent": null,
+              "minQuota": 0,
+              "used": 11888,
+              "bookedActivities": 237
+            },
+            {
+              "label": "CAUSA",
+              "name": "CA, USA",
+              "maxAvailable": 5508,
+              "otherActivities": 749,
+              "quota": null,
+              "quotaPercent": null,
+              "minQuota": 0,
+              "used": 4710,
+              "bookedActivities": 92
+            },
+            {
+              "label": "South Florida",
+              "name": "South Florida",
+              "maxAvailable": 9454,
+              "otherActivities": 1031,
+              "quota": 0,
+              "quotaPercent": 0,
+              "minQuota": 0,
+              "used": 7422,
+              "usedQuotaPercent": 0,
+              "bookedActivities": 143
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "with_areas": {
+    "description": "Request with areas",
+    "request_params": {
+      "dates": [
+        "2025-06-25",
+        "2025-06-26"
+      ],
+      "areas": [
+        "FLUSA",
+        "CAUSA"
+      ]
+    },
+    "processed_params": {
+      "areas": "FLUSA,CAUSA",
+      "dates": "2025-06-25,2025-06-26"
+    },
+    "status_code": 200,
+    "response_data": {
+      "items": [
+        {
+          "date": "2025-06-25",
+          "areas": [
+            {
+              "label": "FLUSA",
+              "name": "FL, USA",
+              "maxAvailable": 14158,
+              "otherActivities": 971,
+              "quota": null,
+              "quotaPercent": null,
+              "minQuota": 0,
+              "used": 11888,
+              "bookedActivities": 237
+            },
+            {
+              "label": "CAUSA",
+              "name": "CA, USA",
+              "maxAvailable": 5508,
+              "otherActivities": 749,
+              "quota": null,
+              "quotaPercent": null,
+              "minQuota": 0,
+              "used": 4710,
+              "bookedActivities": 92
+            }
+          ]
+        },
+        {
+          "date": "2025-06-26",
+          "areas": [
+            {
+              "label": "FLUSA",
+              "name": "FL, USA",
+              "maxAvailable": 15540,
+              "otherActivities": 1080,
+              "quota": null,
+              "quotaPercent": null,
+              "minQuota": 0,
+              "used": 14230,
+              "bookedActivities": 232
+            },
+            {
+              "label": "CAUSA",
+              "name": "CA, USA",
+              "maxAvailable": 5400,
+              "otherActivities": 600,
+              "quota": null,
+              "quotaPercent": null,
+              "minQuota": 0,
+              "used": 4391,
+              "bookedActivities": 55
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "with_categories": {
+    "description": "Request with areas and categories",
+    "request_params": {
+      "dates": [
+        "2025-06-25"
+      ],
+      "areas": [
+        "FLUSA"
+      ],
+      "categories": [
+        "EST",
+        "RES",
+        "COM"
+      ]
+    },
+    "processed_params": {
+      "areas": "FLUSA",
+      "categories": "EST,RES,COM",
+      "dates": "2025-06-25"
+    },
+    "status_code": 200,
+    "response_data": {
+      "items": [
+        {
+          "date": "2025-06-25",
+          "areas": [
+            {
+              "label": "FLUSA",
+              "name": "FL, USA",
+              "maxAvailable": 14158,
+              "otherActivities": 971,
+              "quota": null,
+              "quotaPercent": null,
+              "minQuota": 0,
+              "used": 11888,
+              "bookedActivities": 237
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "with_boolean_flags": {
+    "description": "Request with boolean parameters",
+    "request_params": {
+      "dates": [
+        "2025-06-25"
+      ],
+      "areas": [
+        "FLUSA",
+        "CAUSA"
+      ],
+      "aggregateResults": true,
+      "categoryLevel": false,
+      "intervalLevel": true,
+      "returnStatuses": false,
+      "timeSlotLevel": true
+    },
+    "processed_params": {
+      "aggregateResults": "true",
+      "areas": "FLUSA,CAUSA",
+      "categoryLevel": "false",
+      "dates": "2025-06-25",
+      "intervalLevel": "true",
+      "returnStatuses": "false",
+      "timeSlotLevel": "true"
+    },
+    "status_code": 200,
+    "response_data": {
+      "items": [
+        {
+          "date": "2025-06-25",
+          "areas": [
+            {
+              "maxAvailable": 19666,
+              "otherActivities": 1720,
+              "quota": 0,
+              "used": 16598,
+              "bookedActivities": 329
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/capacity/test_capacity_integration.py
+++ b/tests/capacity/test_capacity_integration.py
@@ -1,0 +1,342 @@
+"""
+Integration tests for capacity module functionality against real OFSC server.
+Tests both getAvailableCapacity and getQuota functions.
+These tests require valid OFSC credentials in .env file.
+"""
+import os
+import pytest
+from datetime import date, timedelta
+
+from ofsc import OFSC
+from ofsc.models import (
+    CapacityRequest, GetCapacityResponse, 
+    GetQuotaRequest, GetQuotaResponse, 
+    QuotaAreaItem, CapacityAreaResponseItem,
+    CsvList
+)
+
+
+@pytest.mark.integration
+class TestCapacityModuleIntegration:
+    """Integration tests for the entire capacity module"""
+    
+    @pytest.fixture(scope="class")
+    def ofsc_instance(self):
+        """Create OFSC instance with real credentials"""
+        
+        # Check for required environment variables
+        required_vars = ["OFSC_CLIENT_ID", "OFSC_CLIENT_SECRET", "OFSC_COMPANY"]
+        missing_vars = [var for var in required_vars if not os.environ.get(var)]
+        
+        if missing_vars:
+            pytest.skip(f"Missing required environment variables: {missing_vars}")
+        
+        return OFSC(
+            clientID=os.environ.get("OFSC_CLIENT_ID"),
+            secret=os.environ.get("OFSC_CLIENT_SECRET"), 
+            companyName=os.environ.get("OFSC_COMPANY"),
+            root=os.environ.get("OFSC_ROOT")
+        )
+    
+    @pytest.fixture
+    def test_dates(self):
+        """Get today and tomorrow for testing"""
+        today = date.today()
+        tomorrow = today + timedelta(days=1)
+        return [today.strftime("%Y-%m-%d"), tomorrow.strftime("%Y-%m-%d")]
+    
+    @pytest.fixture
+    def real_areas(self):
+        """Real capacity areas for testing"""
+        return ["FLUSA", "CAUSA"]
+    
+    @pytest.fixture
+    def real_categories(self):
+        """Real capacity categories for testing"""
+        return ["EST", "RES", "COM"]
+    
+    def test_capacity_module_exists(self, ofsc_instance):
+        """Test that capacity module is properly integrated"""
+        
+        # Verify capacity module exists
+        assert hasattr(ofsc_instance, 'capacity')
+        assert ofsc_instance.capacity is not None
+        
+        # Verify capacity functions exist
+        assert hasattr(ofsc_instance.capacity, 'getAvailableCapacity')
+        assert hasattr(ofsc_instance.capacity, 'getQuota')
+        
+        # Verify functions are callable
+        assert callable(ofsc_instance.capacity.getAvailableCapacity)
+        assert callable(ofsc_instance.capacity.getQuota)
+    
+    def test_available_capacity_basic(self, ofsc_instance, test_dates, real_areas):
+        """Test basic getAvailableCapacity functionality"""
+        
+        # Make request with individual parameters
+        response = ofsc_instance.capacity.getAvailableCapacity(
+            dates=[test_dates[0]],
+            areas=real_areas,
+            availableTimeIntervals="all",
+            calendarTimeIntervals="all"
+        )
+        
+        # Verify response structure
+        assert isinstance(response, GetCapacityResponse)
+        assert len(response.items) == 1
+        assert response.items[0].date == test_dates[0]
+        assert len(response.items[0].areas) >= 1
+        
+        # Verify area structure
+        area = response.items[0].areas[0]
+        assert isinstance(area, CapacityAreaResponseItem)
+        assert area.label is not None
+        assert area.calendar is not None
+        assert len(area.calendar.count) > 0
+    
+    def test_available_capacity_with_categories(self, ofsc_instance, test_dates, real_areas, real_categories):
+        """Test getAvailableCapacity with categories"""
+        
+        response = ofsc_instance.capacity.getAvailableCapacity(
+            dates=[test_dates[0]],
+            areas=real_areas,
+            categories=real_categories,
+            availableTimeIntervals="all",
+            calendarTimeIntervals="all"
+        )
+        
+        # Verify response
+        assert isinstance(response, GetCapacityResponse)
+        assert len(response.items) == 1
+        
+        # Should have requested areas
+        area_labels = [area.label for area in response.items[0].areas]
+        for area_label in real_areas:
+            assert area_label in area_labels
+    
+    def test_quota_vs_capacity_consistency(self, ofsc_instance, test_dates, real_areas):
+        """Test that quota and capacity APIs return consistent area information"""
+        
+        # Get capacity data
+        capacity_response = ofsc_instance.capacity.getAvailableCapacity(
+            dates=[test_dates[0]],
+            areas=real_areas
+        )
+        
+        # Get quota data
+        quota_response = ofsc_instance.capacity.getQuota(
+            dates=[test_dates[0]],
+            areas=real_areas
+        )
+        
+        # Both should return data for the same areas
+        capacity_areas = [area.label for area in capacity_response.items[0].areas]
+        quota_areas = [area.label for area in quota_response.items[0].areas]
+        
+        # Check that requested areas are present in both responses
+        for area_label in real_areas:
+            # Area should be in at least one of the responses
+            assert (area_label in capacity_areas or area_label in quota_areas)
+    
+    def test_capacity_different_intervals(self, ofsc_instance, test_dates, real_areas):
+        """Test capacity with different time intervals"""
+        
+        # Test with different interval settings
+        intervals_to_test = [
+            ("all", "all"),
+            ("15", "all"),
+            ("all", "60")
+        ]
+        
+        for available_interval, calendar_interval in intervals_to_test:
+            response = ofsc_instance.capacity.getAvailableCapacity(
+                dates=[test_dates[0]],
+                areas=real_areas[:1],  # Use just one area for faster testing
+                availableTimeIntervals=available_interval,
+                calendarTimeIntervals=calendar_interval
+            )
+            
+            # Should get valid response regardless of interval settings
+            assert isinstance(response, GetCapacityResponse)
+            assert len(response.items) == 1
+    
+    def test_capacity_multiple_dates(self, ofsc_instance, test_dates, real_areas):
+        """Test capacity and quota with multiple dates"""
+        
+        # Test capacity
+        capacity_response = ofsc_instance.capacity.getAvailableCapacity(
+            dates=test_dates,
+            areas=real_areas
+        )
+        
+        # Test quota
+        quota_response = ofsc_instance.capacity.getQuota(
+            dates=test_dates,
+            areas=real_areas
+        )
+        
+        # Both should return data for both dates
+        assert len(capacity_response.items) == len(test_dates)
+        assert len(quota_response.items) == len(test_dates)
+        
+        # Verify dates match
+        capacity_dates = [item.date for item in capacity_response.items]
+        quota_dates = [item.date for item in quota_response.items]
+        
+        for test_date in test_dates:
+            assert test_date in capacity_dates
+            assert test_date in quota_dates
+    
+    def test_capacity_error_handling(self, ofsc_instance, test_dates):
+        """Test error handling for invalid requests"""
+        
+        # Test capacity with invalid area
+        try:
+            response = ofsc_instance.capacity.getAvailableCapacity(
+                dates=[test_dates[0]],
+                areas=["INVALID_AREA_123"]
+            )
+            # If no exception, check response handles it gracefully
+            assert isinstance(response, GetCapacityResponse)
+        except Exception as e:
+            # Should be a meaningful error
+            assert "area" in str(e).lower() or "not found" in str(e).lower()
+        
+        # Test quota with invalid parameters
+        try:
+            response = ofsc_instance.capacity.getQuota(
+                dates=[test_dates[0]],
+                areas=["INVALID_AREA_456"]
+            )
+            assert isinstance(response, GetQuotaResponse)
+        except Exception as e:
+            assert "area" in str(e).lower() or "not found" in str(e).lower()
+    
+    def test_capacity_model_validation_edge_cases(self, ofsc_instance, test_dates, real_areas):
+        """Test model validation with edge cases"""
+        
+        # Test capacity with empty categories
+        response = ofsc_instance.capacity.getAvailableCapacity(
+            dates=[test_dates[0]],
+            areas=real_areas,
+            categories=[]  # Empty categories
+        )
+        assert isinstance(response, GetCapacityResponse)
+        
+        # Test quota with None optional parameters (should use defaults)
+        response = ofsc_instance.capacity.getQuota(
+            dates=[test_dates[0]],
+            areas=real_areas,
+            categories=None,
+            aggregateResults=None,
+            categoryLevel=None
+        )
+        assert isinstance(response, GetQuotaResponse)
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+class TestCapacityPerformanceIntegration:
+    """Performance and stress tests for capacity module"""
+    
+    @pytest.fixture(scope="class")
+    def ofsc_instance(self):
+        """Create OFSC instance with real credentials"""
+        
+        required_vars = ["OFSC_CLIENT_ID", "OFSC_CLIENT_SECRET", "OFSC_COMPANY"]
+        missing_vars = [var for var in required_vars if not os.environ.get(var)]
+        
+        if missing_vars:
+            pytest.skip(f"Missing required environment variables: {missing_vars}")
+        
+        return OFSC(
+            clientID=os.environ.get("OFSC_CLIENT_ID"),
+            secret=os.environ.get("OFSC_CLIENT_SECRET"), 
+            companyName=os.environ.get("OFSC_COMPANY"),
+            root=os.environ.get("OFSC_ROOT")
+        )
+    
+    def test_capacity_week_range_performance(self, ofsc_instance):
+        """Test capacity API with week-long date range"""
+        import time
+        
+        # Generate week range
+        today = date.today()
+        week_dates = [(today + timedelta(days=i)).strftime("%Y-%m-%d") for i in range(7)]
+        
+        # Test capacity API
+        start_time = time.time()
+        capacity_response = ofsc_instance.capacity.getAvailableCapacity(
+            dates=week_dates,
+            areas=["FLUSA"]
+        )
+        capacity_time = time.time() - start_time
+        
+        # Test quota API
+        start_time = time.time()
+        quota_response = ofsc_instance.capacity.getQuota(
+            dates=week_dates,
+            areas=["FLUSA"]
+        )
+        quota_time = time.time() - start_time
+        
+        # Verify responses
+        assert isinstance(capacity_response, GetCapacityResponse)
+        assert isinstance(quota_response, GetQuotaResponse)
+        assert len(capacity_response.items) == 7
+        assert len(quota_response.items) == 7
+        
+        # Performance assertions (adjust thresholds as needed)
+        assert capacity_time < 15.0  # Should complete within 15 seconds
+        assert quota_time < 10.0     # Should complete within 10 seconds
+        
+        print(f"Capacity API (7 days): {capacity_time:.2f}s")
+        print(f"Quota API (7 days): {quota_time:.2f}s")
+    
+    def test_concurrent_capacity_requests(self, ofsc_instance):
+        """Test multiple concurrent capacity requests"""
+        import concurrent.futures
+        import time
+        
+        today = date.today()
+        tomorrow = (today + timedelta(days=1)).strftime("%Y-%m-%d")
+        today_str = today.strftime("%Y-%m-%d")
+        
+        def make_capacity_request(area):
+            """Make a capacity request for a specific area"""
+            return ofsc_instance.capacity.getAvailableCapacity(
+                dates=[today_str],
+                areas=[area]
+            )
+        
+        def make_quota_request(area):
+            """Make a quota request for a specific area"""
+            return ofsc_instance.capacity.getQuota(
+                dates=[today_str],
+                areas=[area]
+            )
+        
+        areas_to_test = ["FLUSA", "CAUSA"]
+        
+        # Test concurrent capacity requests
+        start_time = time.time()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            capacity_futures = [executor.submit(make_capacity_request, area) for area in areas_to_test]
+            quota_futures = [executor.submit(make_quota_request, area) for area in areas_to_test]
+            
+            # Wait for all to complete
+            capacity_results = [future.result() for future in capacity_futures]
+            quota_results = [future.result() for future in quota_futures]
+        
+        concurrent_time = time.time() - start_time
+        
+        # Verify all requests succeeded
+        for result in capacity_results:
+            assert isinstance(result, GetCapacityResponse)
+        for result in quota_results:
+            assert isinstance(result, GetQuotaResponse)
+        
+        # Should complete reasonably quickly even with concurrent requests
+        assert concurrent_time < 20.0
+        
+        print(f"Concurrent requests ({len(areas_to_test)} areas, both APIs): {concurrent_time:.2f}s")

--- a/tests/capacity/test_capacity_mocked.py
+++ b/tests/capacity/test_capacity_mocked.py
@@ -1,0 +1,542 @@
+"""
+Mocked tests for capacity functionality using mock responses.
+Tests both getAvailableCapacity and getQuota functions.
+"""
+import json
+import pytest
+from unittest.mock import Mock, patch
+from pathlib import Path
+
+from ofsc import OFSC
+from ofsc.models import (
+    CapacityRequest, GetCapacityResponse, 
+    GetQuotaRequest, GetQuotaResponse, 
+    QuotaAreaItem, CsvList
+)
+from ofsc.capacity import _convert_model_to_api_params
+
+
+class TestCapacityAPIMocked:
+    """Test the capacity API with mocked responses"""
+    
+    @pytest.fixture
+    def ofsc_instance(self):
+        """Create OFSC instance for testing"""
+        return OFSC(
+            clientID="test_client",
+            secret="test_secret", 
+            companyName="test_company"
+        )
+    
+    @pytest.fixture
+    def mock_capacity_response(self):
+        """Mock capacity response data"""
+        return {
+            "items": [
+                {
+                    "date": "2025-06-25",
+                    "areas": [
+                        {
+                            "label": "FLUSA",
+                            "name": "FL, USA",
+                            "calendar": {
+                                "count": [480, 480, 480],
+                                "minutes": [28800, 28800, 28800]
+                            },
+                            "available": {
+                                "count": [120, 150, 100],
+                                "minutes": [7200, 9000, 6000]
+                            },
+                            "categories": []
+                        }
+                    ]
+                }
+            ]
+        }
+    
+    def test_available_capacity_request(self, ofsc_instance, mock_capacity_response):
+        """Test getAvailableCapacity function with new individual parameter signature"""
+        
+        with patch('requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = mock_capacity_response
+            mock_get.return_value = mock_response
+            
+            # Make the call with individual parameters
+            result = ofsc_instance.capacity.getAvailableCapacity(
+                dates=["2025-06-25"],
+                areas=["FLUSA", "CAUSA"],
+                availableTimeIntervals="all",
+                calendarTimeIntervals="all"
+            )
+            
+            # Verify it's the correct type
+            assert isinstance(result, GetCapacityResponse)
+            
+            # Verify structure
+            assert len(result.items) == 1
+            assert result.items[0].date == "2025-06-25"
+            assert len(result.items[0].areas) == 1
+            
+            # Verify area data
+            area = result.items[0].areas[0]
+            assert area.label == "FLUSA"
+            assert area.name == "FL, USA"
+            assert area.calendar.count == [480, 480, 480]
+            assert area.available.count == [120, 150, 100]
+            
+            # Verify the request was made to correct endpoint
+            mock_get.assert_called_once()
+            call_args = mock_get.call_args
+            assert "/rest/ofscCapacity/v1/capacity" in call_args[0][0]
+            
+            # Verify parameters were converted correctly
+            params = call_args[1]["params"]
+            assert params["areas"] == "FLUSA,CAUSA"
+            assert params["dates"] == "2025-06-25"
+    
+    def test_available_capacity_different_input_formats(self, ofsc_instance):
+        """Test getAvailableCapacity with different input formats"""
+        
+        mock_response_data = {"items": [{"date": "2025-06-25", "areas": []}]}
+        
+        with patch('requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = mock_response_data
+            mock_get.return_value = mock_response
+            
+            # Test 1: List input
+            ofsc_instance.capacity.getAvailableCapacity(
+                dates=["2025-06-25"],
+                areas=["FLUSA", "CAUSA"]
+            )
+            
+            call_args = mock_get.call_args
+            assert call_args[1]["params"]["areas"] == "FLUSA,CAUSA"
+            assert call_args[1]["params"]["dates"] == "2025-06-25"
+            
+            # Test 2: CSV string input
+            mock_get.reset_mock()
+            ofsc_instance.capacity.getAvailableCapacity(
+                dates="2025-06-25",
+                areas="FLUSA,CAUSA",
+                categories="EST,RES"
+            )
+            
+            call_args = mock_get.call_args
+            assert call_args[1]["params"]["areas"] == "FLUSA,CAUSA"
+            assert call_args[1]["params"]["categories"] == "EST,RES"
+            
+            # Test 3: CsvList input
+            mock_get.reset_mock()
+            ofsc_instance.capacity.getAvailableCapacity(
+                dates=CsvList.from_list(["2025-06-25"]),
+                areas=CsvList.from_list(["FLUSA", "CAUSA"])
+            )
+            
+            call_args = mock_get.call_args
+            assert call_args[1]["params"]["areas"] == "FLUSA,CAUSA"
+    
+    def test_available_capacity_with_optional_parameters(self, ofsc_instance):
+        """Test getAvailableCapacity with optional parameters"""
+        
+        mock_response_data = {"items": []}
+        
+        with patch('requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = mock_response_data
+            mock_get.return_value = mock_response
+            
+            # Test with all parameters
+            ofsc_instance.capacity.getAvailableCapacity(
+                dates=["2025-06-25"],
+                areas=["FLUSA"],
+                categories=["EST"],
+                aggregateResults=True,
+                availableTimeIntervals="15",
+                calendarTimeIntervals="60",
+                fields=["label", "name"]
+            )
+            
+            call_args = mock_get.call_args
+            params = call_args[1]["params"]
+            
+            assert params["aggregateResults"] == "true"  # Should be converted to lowercase
+            assert params["availableTimeIntervals"] == "15"
+            assert params["calendarTimeIntervals"] == "60"
+            assert params["fields"] == ["label", "name"]
+
+
+class TestQuotaRequestValidation:
+    """Test GetQuotaRequest model validation and conversion"""
+    
+    def test_quota_request_with_lists(self):
+        """Test GetQuotaRequest with list inputs (should work with validators)"""
+        
+        # This should work because of the field validators
+        request = GetQuotaRequest(
+            dates=["2025-06-25", "2025-06-26"],
+            areas=["FLUSA", "CAUSA"],
+            categories=["EST", "RES"]
+        )
+        
+        assert isinstance(request.dates, CsvList)
+        assert isinstance(request.areas, CsvList)
+        assert isinstance(request.categories, CsvList)
+        
+        # Test conversion back to lists
+        assert request.get_dates_list() == ["2025-06-25", "2025-06-26"]
+        assert request.get_areas_list() == ["FLUSA", "CAUSA"]
+        assert request.get_categories_list() == ["EST", "RES"]
+    
+    def test_quota_request_with_csv_strings(self):
+        """Test GetQuotaRequest with CSV string inputs"""
+        
+        request = GetQuotaRequest(
+            dates="2025-06-25,2025-06-26",
+            areas="FLUSA,CAUSA",
+            categories="EST,RES"
+        )
+        
+        assert request.get_dates_list() == ["2025-06-25", "2025-06-26"]
+        assert request.get_areas_list() == ["FLUSA", "CAUSA"]
+        assert request.get_categories_list() == ["EST", "RES"]
+    
+    def test_quota_request_with_csvlist_objects(self):
+        """Test GetQuotaRequest with CsvList inputs"""
+        
+        request = GetQuotaRequest(
+            dates=CsvList.from_list(["2025-06-25"]),
+            areas=CsvList.from_list(["FLUSA"]),
+            categories=CsvList.from_list(["EST"])
+        )
+        
+        assert request.get_dates_list() == ["2025-06-25"]
+        assert request.get_areas_list() == ["FLUSA"]
+        assert request.get_categories_list() == ["EST"]
+    
+    def test_quota_request_optional_fields(self):
+        """Test GetQuotaRequest with optional fields"""
+        
+        # Minimal request (only dates required)
+        minimal_request = GetQuotaRequest(dates=["2025-06-25"])
+        
+        assert minimal_request.get_dates_list() == ["2025-06-25"]
+        assert minimal_request.get_areas_list() == []
+        assert minimal_request.get_categories_list() == []
+        assert minimal_request.aggregateResults is None
+        assert minimal_request.categoryLevel is None
+        
+        # Request with boolean fields
+        bool_request = GetQuotaRequest(
+            dates=["2025-06-25"],
+            aggregateResults=True,
+            categoryLevel=False,
+            intervalLevel=True
+        )
+        
+        assert bool_request.aggregateResults is True
+        assert bool_request.categoryLevel is False
+        assert bool_request.intervalLevel is True
+        assert bool_request.returnStatuses is None
+        assert bool_request.timeSlotLevel is None
+
+
+class TestQuotaResponseModel:
+    """Test QuotaAreaItem and related models"""
+    
+    def test_quota_area_item_creation(self):
+        """Test QuotaAreaItem model creation with various field combinations"""
+        
+        # Full area data
+        full_area = QuotaAreaItem(
+            label="FLUSA",
+            name="FL, USA",
+            maxAvailable=14158,
+            otherActivities=971,
+            quota=None,
+            quotaPercent=None,
+            minQuota=0,
+            used=11888,
+            usedQuotaPercent=None,
+            bookedActivities=237
+        )
+        
+        assert full_area.label == "FLUSA"
+        assert full_area.name == "FL, USA"
+        assert full_area.maxAvailable == 14158
+        assert full_area.bookedActivities == 237
+        
+        # Area with quota set
+        quota_area = QuotaAreaItem(
+            label="South Florida",
+            name="South Florida", 
+            maxAvailable=9454,
+            quota=0,
+            quotaPercent=0,
+            usedQuotaPercent=0,
+            bookedActivities=143
+        )
+        
+        assert quota_area.quota == 0
+        assert quota_area.quotaPercent == 0
+        assert quota_area.usedQuotaPercent == 0
+        
+        # Aggregated area (no label)
+        aggregated_area = QuotaAreaItem(
+            maxAvailable=19666,
+            used=16598,
+            bookedActivities=329
+        )
+        
+        assert aggregated_area.label is None
+        assert aggregated_area.maxAvailable == 19666
+        assert aggregated_area.used == 16598
+
+
+class TestCsvListModel:
+    """Test CsvList utility model"""
+    
+    def test_csvlist_from_list(self):
+        """Test CsvList creation from list"""
+        
+        # Normal list
+        csv_list = CsvList.from_list(["FLUSA", "CAUSA", "EST"])
+        assert csv_list.value == "FLUSA,CAUSA,EST"
+        assert csv_list.to_list() == ["FLUSA", "CAUSA", "EST"]
+        
+        # Empty list
+        empty_csv = CsvList.from_list([])
+        assert empty_csv.value == ""
+        assert empty_csv.to_list() == []
+        
+        # Single item
+        single_csv = CsvList.from_list(["FLUSA"])
+        assert single_csv.value == "FLUSA"
+        assert single_csv.to_list() == ["FLUSA"]
+    
+    def test_csvlist_to_list(self):
+        """Test CsvList conversion to list"""
+        
+        # Normal CSV
+        csv_list = CsvList(value="FLUSA,CAUSA,EST")
+        assert csv_list.to_list() == ["FLUSA", "CAUSA", "EST"]
+        
+        # CSV with spaces
+        spaced_csv = CsvList(value="FLUSA, CAUSA , EST ")
+        assert spaced_csv.to_list() == ["FLUSA", "CAUSA", "EST"]
+        
+        # Empty string
+        empty_csv = CsvList(value="")
+        assert empty_csv.to_list() == []
+        
+        # Whitespace only
+        whitespace_csv = CsvList(value="   ")
+        assert whitespace_csv.to_list() == []
+    
+    def test_csvlist_string_methods(self):
+        """Test CsvList string representation methods"""
+        
+        csv_list = CsvList.from_list(["FLUSA", "CAUSA"])
+        
+        # String representation should return CSV value
+        assert str(csv_list) == "FLUSA,CAUSA"
+        
+        # Repr should show both formats
+        repr_str = repr(csv_list)
+        assert "CsvList(value='FLUSA,CAUSA'" in repr_str
+        assert "list=['FLUSA', 'CAUSA']" in repr_str
+
+
+class TestCapacityRequestModel:
+    """Test CapacityRequest model with CsvList support"""
+    
+    def test_capacity_request_with_lists(self):
+        """Test CapacityRequest model creation with list inputs"""
+        
+        request = CapacityRequest(
+            areas=["FLUSA", "CAUSA"],
+            dates=["2025-06-25", "2025-06-26"],
+            availableTimeIntervals="all",
+            calendarTimeIntervals="all",
+            categories=["EST", "RES"],
+            aggregateResults=True
+        )
+        
+        assert isinstance(request.areas, CsvList)
+        assert isinstance(request.dates, CsvList)
+        assert isinstance(request.categories, CsvList)
+        assert request.get_areas_list() == ["FLUSA", "CAUSA"]
+        assert request.get_dates_list() == ["2025-06-25", "2025-06-26"]
+        assert request.get_categories_list() == ["EST", "RES"]
+        assert request.availableTimeIntervals == "all"
+        assert request.calendarTimeIntervals == "all"
+        assert request.aggregateResults is True
+    
+    def test_capacity_request_with_csv_strings(self):
+        """Test CapacityRequest with CSV string inputs"""
+        
+        request = CapacityRequest(
+            areas="FLUSA,CAUSA",
+            dates="2025-06-25,2025-06-26",
+            categories="EST,RES"
+        )
+        
+        assert request.get_areas_list() == ["FLUSA", "CAUSA"]
+        assert request.get_dates_list() == ["2025-06-25", "2025-06-26"]
+        assert request.get_categories_list() == ["EST", "RES"]
+    
+    def test_capacity_request_with_csvlist_objects(self):
+        """Test CapacityRequest with CsvList inputs"""
+        
+        request = CapacityRequest(
+            areas=CsvList.from_list(["FLUSA"]),
+            dates=CsvList.from_list(["2025-06-25"]),
+            categories=CsvList.from_list(["EST"])
+        )
+        
+        assert request.get_areas_list() == ["FLUSA"]
+        assert request.get_dates_list() == ["2025-06-25"]
+        assert request.get_categories_list() == ["EST"]
+    
+    def test_capacity_request_defaults(self):
+        """Test CapacityRequest model with default values"""
+        
+        # Minimal request
+        request = CapacityRequest(
+            areas=["FLUSA"],
+            dates=["2025-06-25"]
+        )
+        
+        # Check defaults
+        assert request.availableTimeIntervals == "all"
+        assert request.calendarTimeIntervals == "all"
+        assert request.get_categories_list() == []  # None categories should return empty list
+        assert request.aggregateResults is None
+        assert request.fields is None
+
+
+class TestGenericConverter:
+    """Test the internal _convert_model_to_api_params function"""
+    
+    def test_capacity_request_conversion(self):
+        """Test conversion of CapacityRequest with various field types"""
+        
+        request = CapacityRequest(
+            dates=["2025-06-25", "2025-06-26"],
+            areas=["FLUSA", "CAUSA"],
+            categories=["EST", "RES"],
+            aggregateResults=True,
+            availableTimeIntervals="15",
+            calendarTimeIntervals="all"
+        )
+        
+        params = _convert_model_to_api_params(request)
+        
+        # Verify CsvList fields are converted to strings
+        assert params['dates'] == "2025-06-25,2025-06-26"
+        assert params['areas'] == "FLUSA,CAUSA"
+        assert params['categories'] == "EST,RES"
+        
+        # Verify boolean field is converted to lowercase string
+        assert params['aggregateResults'] == "true"
+        
+        # Verify string fields remain unchanged
+        assert params['availableTimeIntervals'] == "15"
+        assert params['calendarTimeIntervals'] == "all"
+    
+    def test_quota_request_conversion(self):
+        """Test conversion of GetQuotaRequest with boolean fields"""
+        
+        request = GetQuotaRequest(
+            dates=["2025-06-25"],
+            areas=["FLUSA"],
+            aggregateResults=True,
+            categoryLevel=False,
+            intervalLevel=True,
+            returnStatuses=False,
+            timeSlotLevel=True
+        )
+        
+        params = _convert_model_to_api_params(request)
+        
+        # Verify CsvList fields
+        assert params['dates'] == "2025-06-25"
+        assert params['areas'] == "FLUSA"
+        
+        # Verify all boolean fields are converted to lowercase strings
+        assert params['aggregateResults'] == "true"
+        assert params['categoryLevel'] == "false"
+        assert params['intervalLevel'] == "true"
+        assert params['returnStatuses'] == "false"
+        assert params['timeSlotLevel'] == "true"
+    
+    def test_optional_field_exclusion(self):
+        """Test that None optional fields are excluded"""
+        
+        request = CapacityRequest(
+            dates=["2025-06-25"],
+            areas=["FLUSA"]
+            # categories omitted (None)
+        )
+        
+        params = _convert_model_to_api_params(request)
+        
+        # Required fields should be present
+        assert 'dates' in params
+        assert 'areas' in params
+        
+        # None optional fields should be excluded
+        assert 'categories' not in params
+        
+        # Default values should be included
+        assert params['availableTimeIntervals'] == "all"
+        assert params['calendarTimeIntervals'] == "all"
+    
+    def test_different_input_formats(self):
+        """Test conversion with different input formats"""
+        
+        # CSV string inputs
+        request1 = CapacityRequest(
+            dates="2025-06-25,2025-06-26",
+            areas="FLUSA,CAUSA"
+        )
+        
+        params1 = _convert_model_to_api_params(request1)
+        assert params1['dates'] == "2025-06-25,2025-06-26"
+        assert params1['areas'] == "FLUSA,CAUSA"
+        
+        # CsvList inputs
+        request2 = CapacityRequest(
+            dates=CsvList.from_list(["2025-06-25"]),
+            areas=CsvList.from_list(["FLUSA"])
+        )
+        
+        params2 = _convert_model_to_api_params(request2)
+        assert params2['dates'] == "2025-06-25"
+        assert params2['areas'] == "FLUSA"
+    
+    def test_type_inspection_accuracy(self):
+        """Test that type inspection correctly identifies field types"""
+        
+        # Create a request with mixed field types
+        request = GetQuotaRequest(
+            dates=["2025-06-25"],  # CsvList field
+            aggregateResults=True,  # Optional[bool] field
+            categoryLevel=False,    # Optional[bool] field
+        )
+        
+        params = _convert_model_to_api_params(request)
+        
+        # Verify type inspection worked correctly
+        assert isinstance(params['dates'], str)  # CsvList -> str
+        assert isinstance(params['aggregateResults'], str)  # bool -> str
+        assert isinstance(params['categoryLevel'], str)  # bool -> str
+        
+        # Verify actual conversions
+        assert params['dates'] == "2025-06-25"
+        assert params['aggregateResults'] == "true"
+        assert params['categoryLevel'] == "false"

--- a/tests/capacity/test_quota_integration.py
+++ b/tests/capacity/test_quota_integration.py
@@ -1,0 +1,318 @@
+"""
+Integration tests for capacity quota functionality against real OFSC server.
+These tests require valid OFSC credentials in .env file.
+"""
+import os
+import pytest
+from datetime import date, timedelta
+
+from ofsc import OFSC
+from ofsc.models import GetQuotaRequest, GetQuotaResponse, QuotaAreaItem, CsvList
+
+
+@pytest.mark.integration
+class TestQuotaAPIIntegration:
+    """Integration tests against real OFSC server"""
+    
+    @pytest.fixture(scope="class")
+    def ofsc_instance(self):
+        """Create OFSC instance with real credentials"""
+        
+        # Check for required environment variables
+        required_vars = ["OFSC_CLIENT_ID", "OFSC_CLIENT_SECRET", "OFSC_COMPANY"]
+        missing_vars = [var for var in required_vars if not os.environ.get(var)]
+        
+        if missing_vars:
+            pytest.skip(f"Missing required environment variables: {missing_vars}")
+        
+        return OFSC(
+            clientID=os.environ.get("OFSC_CLIENT_ID"),
+            secret=os.environ.get("OFSC_CLIENT_SECRET"), 
+            companyName=os.environ.get("OFSC_COMPANY"),
+            root=os.environ.get("OFSC_ROOT")
+        )
+    
+    @pytest.fixture
+    def test_dates(self):
+        """Get today and tomorrow for testing"""
+        today = date.today()
+        tomorrow = today + timedelta(days=1)
+        return [today.strftime("%Y-%m-%d"), tomorrow.strftime("%Y-%m-%d")]
+    
+    @pytest.fixture
+    def real_areas(self):
+        """Real capacity areas for testing"""
+        return ["FLUSA", "CAUSA"]
+    
+    @pytest.fixture
+    def real_categories(self):
+        """Real capacity categories for testing"""
+        return ["EST", "RES", "COM"]
+    
+    def test_quota_minimal_request(self, ofsc_instance, test_dates):
+        """Test minimal quota request with only dates"""
+        
+        response = ofsc_instance.capacity.getQuota(dates=[test_dates[0]])
+        
+        # Verify response structure
+        assert isinstance(response, GetQuotaResponse)
+        assert len(response.items) == 1
+        assert response.items[0].date == test_dates[0]
+        assert len(response.items[0].areas) > 0
+        
+        # Verify area structure
+        first_area = response.items[0].areas[0]
+        assert isinstance(first_area, QuotaAreaItem)
+        assert first_area.label is not None
+        assert isinstance(first_area.maxAvailable, int)
+    
+    def test_quota_with_areas(self, ofsc_instance, test_dates, real_areas):
+        """Test quota request with specific areas"""
+        
+        response = ofsc_instance.capacity.getQuota(
+            dates=test_dates,
+            areas=real_areas
+        )
+        
+        # Verify response structure
+        assert isinstance(response, GetQuotaResponse)
+        assert len(response.items) == 2  # Two dates
+        
+        # Verify each date has the requested areas
+        for item in response.items:
+            assert item.date in test_dates
+            assert len(item.areas) == len(real_areas)
+            
+            # Verify area labels match what was requested
+            area_labels = [area.label for area in item.areas]
+            for area_label in real_areas:
+                assert area_label in area_labels
+    
+    def test_quota_with_categories(self, ofsc_instance, test_dates, real_areas, real_categories):
+        """Test quota request with areas and categories"""
+        
+        response = ofsc_instance.capacity.getQuota(
+            dates=[test_dates[0]],
+            areas=real_areas,
+            categories=real_categories
+        )
+        
+        # Verify response structure
+        assert isinstance(response, GetQuotaResponse)
+        assert len(response.items) == 1
+        
+        # Should have areas matching the request
+        area_labels = [area.label for area in response.items[0].areas]
+        for area_label in real_areas:
+            assert area_label in area_labels
+    
+    def test_quota_with_boolean_parameters(self, ofsc_instance, test_dates, real_areas):
+        """Test quota request with boolean parameters"""
+        
+        response = ofsc_instance.capacity.getQuota(
+            dates=[test_dates[0]],
+            areas=real_areas,
+            aggregateResults=True,
+            categoryLevel=False,
+            intervalLevel=True,
+            returnStatuses=False,
+            timeSlotLevel=True
+        )
+        
+        # Verify response structure
+        assert isinstance(response, GetQuotaResponse)
+        assert len(response.items) == 1
+        
+        # With aggregateResults=True, we should get aggregated data
+        # (may not have individual area labels)
+        assert len(response.items[0].areas) >= 1
+        
+        # Verify aggregated area has expected fields
+        area = response.items[0].areas[0]
+        assert area.maxAvailable is not None
+        assert area.used is not None
+    
+    def test_quota_different_input_formats(self, ofsc_instance, test_dates, real_areas):
+        """Test different input formats produce same results"""
+        
+        # Test 1: List format
+        response1 = ofsc_instance.capacity.getQuota(
+            dates=test_dates[:1],
+            areas=real_areas
+        )
+        
+        # Test 2: CSV string format
+        response2 = ofsc_instance.capacity.getQuota(
+            dates=test_dates[0],
+            areas=",".join(real_areas)
+        )
+        
+        # Test 3: CsvList format
+        response3 = ofsc_instance.capacity.getQuota(
+            dates=CsvList.from_list(test_dates[:1]),
+            areas=CsvList.from_list(real_areas)
+        )
+        
+        # All responses should be equivalent
+        assert len(response1.items) == len(response2.items) == len(response3.items)
+        assert response1.items[0].date == response2.items[0].date == response3.items[0].date
+        
+        # Number of areas should match
+        assert len(response1.items[0].areas) == len(response2.items[0].areas) == len(response3.items[0].areas)
+    
+    def test_quota_error_handling(self, ofsc_instance, test_dates):
+        """Test error handling for invalid parameters"""
+        
+        # Test with invalid area (should not raise exception due to auto_model handling)
+        try:
+            response = ofsc_instance.capacity.getQuota(
+                dates=test_dates[:1],
+                areas=["INVALID_AREA_123"]
+            )
+            # If no exception, check if response is empty or handles gracefully
+            assert isinstance(response, GetQuotaResponse)
+        except Exception as e:
+            # If exception is raised, it should be a meaningful error
+            assert "area" in str(e).lower() or "not found" in str(e).lower()
+    
+    def test_quota_request_model_creation(self, test_dates, real_areas, real_categories):
+        """Test GetQuotaRequest model creation and validation"""
+        
+        # Test full request
+        request = GetQuotaRequest(
+            dates=test_dates,
+            areas=real_areas,
+            categories=real_categories,
+            aggregateResults=True,
+            categoryLevel=False,
+            intervalLevel=True,
+            returnStatuses=False,
+            timeSlotLevel=True
+        )
+        
+        # Verify all fields are set correctly
+        assert request.get_dates_list() == test_dates
+        assert request.get_areas_list() == real_areas
+        assert request.get_categories_list() == real_categories
+        assert request.aggregateResults is True
+        assert request.categoryLevel is False
+        assert request.intervalLevel is True
+        assert request.returnStatuses is False
+        assert request.timeSlotLevel is True
+        
+        # Test minimal request (only dates required)
+        minimal_request = GetQuotaRequest(dates=[test_dates[0]])
+        assert minimal_request.get_dates_list() == [test_dates[0]]
+        assert minimal_request.get_areas_list() == []
+        assert minimal_request.get_categories_list() == []
+        assert minimal_request.aggregateResults is None
+    
+    def test_quota_response_model_validation(self, ofsc_instance, test_dates, real_areas):
+        """Test that response models validate correctly with real data"""
+        
+        response = ofsc_instance.capacity.getQuota(
+            dates=[test_dates[0]],
+            areas=real_areas
+        )
+        
+        # Verify response model structure
+        assert isinstance(response, GetQuotaResponse)
+        assert hasattr(response, "items")
+        assert len(response.items) > 0
+        
+        # Verify item structure
+        item = response.items[0]
+        assert hasattr(item, "date")
+        assert hasattr(item, "areas")
+        assert isinstance(item.date, str)
+        assert isinstance(item.areas, list)
+        
+        # Verify area structure
+        if item.areas:
+            area = item.areas[0]
+            assert isinstance(area, QuotaAreaItem)
+            
+            # Check that required fields are present
+            assert hasattr(area, "maxAvailable")
+            assert hasattr(area, "bookedActivities")
+            assert hasattr(area, "used")
+            
+            # Verify field types
+            if area.maxAvailable is not None:
+                assert isinstance(area.maxAvailable, int)
+            if area.bookedActivities is not None:
+                assert isinstance(area.bookedActivities, int)
+            if area.used is not None:
+                assert isinstance(area.used, int)
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+class TestQuotaAPIPerformance:
+    """Performance tests for quota API"""
+    
+    @pytest.fixture(scope="class")
+    def ofsc_instance(self):
+        """Create OFSC instance with real credentials"""
+        
+        required_vars = ["OFSC_CLIENT_ID", "OFSC_CLIENT_SECRET", "OFSC_COMPANY"]
+        missing_vars = [var for var in required_vars if not os.environ.get(var)]
+        
+        if missing_vars:
+            pytest.skip(f"Missing required environment variables: {missing_vars}")
+        
+        return OFSC(
+            clientID=os.environ.get("OFSC_CLIENT_ID"),
+            secret=os.environ.get("OFSC_CLIENT_SECRET"), 
+            companyName=os.environ.get("OFSC_COMPANY"),
+            root=os.environ.get("OFSC_ROOT")
+        )
+    
+    def test_quota_multiple_dates_performance(self, ofsc_instance):
+        """Test performance with multiple dates"""
+        import time
+        
+        # Generate date range (7 days)
+        today = date.today()
+        date_range = [(today + timedelta(days=i)).strftime("%Y-%m-%d") for i in range(7)]
+        
+        start_time = time.time()
+        response = ofsc_instance.capacity.getQuota(
+            dates=date_range,
+            areas=["FLUSA", "CAUSA"]
+        )
+        end_time = time.time()
+        
+        # Verify response
+        assert isinstance(response, GetQuotaResponse)
+        assert len(response.items) == 7
+        
+        # Performance check (should complete in reasonable time)
+        execution_time = end_time - start_time
+        assert execution_time < 10.0  # Should complete within 10 seconds
+        
+        print(f"Multiple dates query took {execution_time:.2f} seconds")
+    
+    def test_quota_large_area_set_performance(self, ofsc_instance):
+        """Test performance with multiple areas (if available)"""
+        import time
+        
+        today = date.today()
+        
+        # Try with multiple areas (adjust based on available areas)
+        areas = ["FLUSA", "CAUSA"]  # Add more if available in your environment
+        
+        start_time = time.time()
+        response = ofsc_instance.capacity.getQuota(
+            dates=[today.strftime("%Y-%m-%d")],
+            areas=areas
+        )
+        end_time = time.time()
+        
+        # Verify response
+        assert isinstance(response, GetQuotaResponse)
+        
+        execution_time = end_time - start_time
+        assert execution_time < 5.0  # Should complete within 5 seconds
+        
+        print(f"Multiple areas query took {execution_time:.2f} seconds")

--- a/tests/capacity/test_quota_mocked.py
+++ b/tests/capacity/test_quota_mocked.py
@@ -1,0 +1,357 @@
+"""
+Mocked tests for capacity quota functionality using real server response data.
+These tests use captured real responses to ensure consistent testing without server dependency.
+"""
+import json
+import pytest
+from unittest.mock import Mock, patch
+from pathlib import Path
+
+from ofsc import OFSC
+from ofsc.models import GetQuotaRequest, GetQuotaResponse, QuotaAreaItem, QuotaResponseItem, CsvList
+
+
+class TestQuotaAPIMocked:
+    """Test the quota API with mocked responses based on real server data"""
+    
+    @pytest.fixture
+    def real_responses(self):
+        """Load real server responses from captured JSON"""
+        responses_file = Path(__file__).parent / "real_responses.json"
+        with open(responses_file, 'r') as f:
+            return json.load(f)
+    
+    @pytest.fixture
+    def ofsc_instance(self):
+        """Create OFSC instance for testing"""
+        return OFSC(
+            clientID="test_client",
+            secret="test_secret", 
+            companyName="test_company"
+        )
+    
+    def test_quota_minimal_dates_only(self, ofsc_instance, real_responses):
+        """Test quota request with only dates (minimal case)"""
+        
+        # Get real response data
+        scenario_data = real_responses["minimal_dates_only"]
+        mock_response_data = scenario_data["response_data"]
+        
+        # Mock the requests.get call
+        with patch('requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = mock_response_data
+            mock_get.return_value = mock_response
+            
+            # Make the call
+            result = ofsc_instance.capacity.getQuota(dates=["2025-06-25"])
+            
+            # Verify it's the correct type
+            assert isinstance(result, GetQuotaResponse)
+            
+            # Verify structure
+            assert len(result.items) == 1
+            assert result.items[0].date == "2025-06-25"
+            assert len(result.items[0].areas) == 4
+            
+            # Verify specific area data
+            flusa_area = next((area for area in result.items[0].areas if area.label == "FLUSA"), None)
+            assert flusa_area is not None
+            assert flusa_area.name == "FL, USA"
+            assert flusa_area.maxAvailable == 14158
+            assert flusa_area.bookedActivities == 237
+            assert flusa_area.used == 11888
+            
+            # Verify the request was made correctly
+            mock_get.assert_called_once()
+            call_args = mock_get.call_args
+            assert "/rest/ofscCapacity/v2/quota" in call_args[0][0]
+            assert call_args[1]["params"]["dates"] == "2025-06-25"
+    
+    def test_quota_with_areas(self, ofsc_instance, real_responses):
+        """Test quota request with specific areas"""
+        
+        scenario_data = real_responses["with_areas"]
+        mock_response_data = scenario_data["response_data"]
+        
+        with patch('requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = mock_response_data
+            mock_get.return_value = mock_response
+            
+            # Test with list of areas
+            result = ofsc_instance.capacity.getQuota(
+                dates=["2025-06-25", "2025-06-26"],
+                areas=["FLUSA", "CAUSA"]
+            )
+            
+            # Verify structure
+            assert isinstance(result, GetQuotaResponse)
+            assert len(result.items) == 2
+            
+            # Verify first date
+            first_item = result.items[0]
+            assert first_item.date == "2025-06-25"
+            assert len(first_item.areas) == 2
+            
+            # Verify FLUSA and CAUSA are present
+            area_labels = [area.label for area in first_item.areas]
+            assert "FLUSA" in area_labels
+            assert "CAUSA" in area_labels
+            
+            # Verify second date
+            second_item = result.items[1]
+            assert second_item.date == "2025-06-26"
+            assert len(second_item.areas) == 2
+            
+            # Verify request parameters
+            call_args = mock_get.call_args
+            assert call_args[1]["params"]["areas"] == "FLUSA,CAUSA"
+            assert call_args[1]["params"]["dates"] == "2025-06-25,2025-06-26"
+    
+    def test_quota_with_categories(self, ofsc_instance, real_responses):
+        """Test quota request with categories"""
+        
+        scenario_data = real_responses["with_categories"]
+        mock_response_data = scenario_data["response_data"]
+        
+        with patch('requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = mock_response_data
+            mock_get.return_value = mock_response
+            
+            # Test with categories
+            result = ofsc_instance.capacity.getQuota(
+                dates=["2025-06-25"],
+                areas=["FLUSA"],
+                categories=["EST", "RES", "COM"]
+            )
+            
+            # Verify structure
+            assert isinstance(result, GetQuotaResponse)
+            assert len(result.items) == 1
+            assert len(result.items[0].areas) == 1
+            
+            # Verify area data
+            area = result.items[0].areas[0]
+            assert area.label == "FLUSA"
+            assert area.name == "FL, USA"
+            
+            # Verify request parameters included categories
+            call_args = mock_get.call_args
+            assert call_args[1]["params"]["categories"] == "EST,RES,COM"
+    
+    def test_quota_with_boolean_parameters(self, ofsc_instance, real_responses):
+        """Test quota request with boolean parameters"""
+        
+        scenario_data = real_responses["with_boolean_flags"]
+        mock_response_data = scenario_data["response_data"]
+        
+        with patch('requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = mock_response_data
+            mock_get.return_value = mock_response
+            
+            # Test with boolean flags
+            result = ofsc_instance.capacity.getQuota(
+                dates=["2025-06-25"],
+                areas=["FLUSA", "CAUSA"],
+                aggregateResults=True,
+                categoryLevel=False,
+                intervalLevel=True,
+                returnStatuses=False,
+                timeSlotLevel=True
+            )
+            
+            # Verify structure
+            assert isinstance(result, GetQuotaResponse)
+            assert len(result.items) == 1
+            assert len(result.items[0].areas) == 1
+            
+            # Verify aggregated area data (no label when aggregated)
+            area = result.items[0].areas[0]
+            assert area.label is None  # Aggregated results don't have labels
+            assert area.maxAvailable == 19666
+            assert area.used == 16598
+            assert area.bookedActivities == 329
+            
+            # Verify boolean parameters were converted to lowercase strings
+            call_args = mock_get.call_args
+            params = call_args[1]["params"]
+            assert params["aggregateResults"] == "true"
+            assert params["categoryLevel"] == "false"
+            assert params["intervalLevel"] == "true"
+            assert params["returnStatuses"] == "false"
+            assert params["timeSlotLevel"] == "true"
+    
+    def test_quota_request_model_validation(self):
+        """Test GetQuotaRequest model validation and conversion"""
+        
+        # Test with list[str] - should convert to CsvList
+        request = GetQuotaRequest(
+            dates=["2025-06-25", "2025-06-26"],
+            areas=["FLUSA", "CAUSA"],
+            categories=["EST", "RES"]
+        )
+        
+        assert isinstance(request.dates, CsvList)
+        assert isinstance(request.areas, CsvList)
+        assert isinstance(request.categories, CsvList)
+        
+        # Test conversion back to lists
+        assert request.get_dates_list() == ["2025-06-25", "2025-06-26"]
+        assert request.get_areas_list() == ["FLUSA", "CAUSA"]
+        assert request.get_categories_list() == ["EST", "RES"]
+        
+        # Test with CSV strings
+        request2 = GetQuotaRequest(
+            dates="2025-06-25,2025-06-26",
+            areas="FLUSA,CAUSA",
+            categories="EST,RES"
+        )
+        
+        assert request2.get_dates_list() == ["2025-06-25", "2025-06-26"]
+        assert request2.get_areas_list() == ["FLUSA", "CAUSA"]
+        assert request2.get_categories_list() == ["EST", "RES"]
+        
+        # Test with CsvList objects
+        request3 = GetQuotaRequest(
+            dates=CsvList.from_list(["2025-06-25"]),
+            areas=CsvList.from_list(["FLUSA"]),
+            categories=CsvList.from_list(["EST"])
+        )
+        
+        assert request3.get_dates_list() == ["2025-06-25"]
+        assert request3.get_areas_list() == ["FLUSA"]
+        assert request3.get_categories_list() == ["EST"]
+    
+    def test_quota_area_item_model(self, real_responses):
+        """Test QuotaAreaItem model with real data"""
+        
+        # Get real area data
+        scenario_data = real_responses["minimal_dates_only"]
+        area_data = scenario_data["response_data"]["items"][0]["areas"][0]
+        
+        # Create model from real data
+        area_item = QuotaAreaItem(**area_data)
+        
+        # Verify all fields are correctly mapped
+        assert area_item.label == "routing_old"
+        assert area_item.name == "Planning"
+        assert area_item.maxAvailable == 47539
+        assert area_item.otherActivities == 0
+        assert area_item.quota is None
+        assert area_item.quotaPercent is None
+        assert area_item.minQuota == 0
+        assert area_item.used == 0
+        assert area_item.bookedActivities == 0
+        
+        # Test area with quota set
+        quota_area_data = real_responses["minimal_dates_only"]["response_data"]["items"][0]["areas"][3]
+        quota_area = QuotaAreaItem(**quota_area_data)
+        
+        assert quota_area.label == "South Florida"
+        assert quota_area.quota == 0
+        assert quota_area.quotaPercent == 0
+        assert quota_area.usedQuotaPercent == 0
+    
+    def test_csv_list_conversion_edge_cases(self):
+        """Test CsvList conversion edge cases"""
+        
+        # Empty list
+        empty_csv = CsvList.from_list([])
+        assert empty_csv.value == ""
+        assert empty_csv.to_list() == []
+        
+        # Single item
+        single_csv = CsvList.from_list(["FLUSA"])
+        assert single_csv.value == "FLUSA"
+        assert single_csv.to_list() == ["FLUSA"]
+        
+        # Multiple items with spaces
+        spaced_csv = CsvList(value="FLUSA, CAUSA , EST")
+        assert spaced_csv.to_list() == ["FLUSA", "CAUSA", "EST"]
+        
+        # Empty string handling
+        empty_string_csv = CsvList(value="")
+        assert empty_string_csv.to_list() == []
+        
+        # String representation
+        test_csv = CsvList.from_list(["FLUSA", "CAUSA"])
+        assert str(test_csv) == "FLUSA,CAUSA"
+        assert "CsvList(value='FLUSA,CAUSA'" in repr(test_csv)
+
+
+class TestQuotaAPIInputFormats:
+    """Test different input formats for quota API"""
+    
+    @pytest.fixture
+    def ofsc_instance(self):
+        return OFSC(clientID="test", secret="test", companyName="test")
+    
+    def test_different_input_formats(self, ofsc_instance):
+        """Test that different input formats all work correctly"""
+        
+        mock_response_data = {"items": [{"date": "2025-06-25", "areas": []}]}
+        
+        with patch('requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = mock_response_data
+            mock_get.return_value = mock_response
+            
+            # Test 1: List input
+            ofsc_instance.capacity.getQuota(
+                dates=["2025-06-25"],
+                areas=["FLUSA", "CAUSA"]
+            )
+            
+            call_args = mock_get.call_args
+            assert call_args[1]["params"]["areas"] == "FLUSA,CAUSA"
+            
+            # Test 2: CSV string input
+            mock_get.reset_mock()
+            ofsc_instance.capacity.getQuota(
+                dates="2025-06-25",
+                areas="FLUSA,CAUSA"
+            )
+            
+            call_args = mock_get.call_args
+            assert call_args[1]["params"]["areas"] == "FLUSA,CAUSA"
+            
+            # Test 3: CsvList input
+            mock_get.reset_mock()
+            ofsc_instance.capacity.getQuota(
+                dates=CsvList.from_list(["2025-06-25"]),
+                areas=CsvList.from_list(["FLUSA", "CAUSA"])
+            )
+            
+            call_args = mock_get.call_args
+            assert call_args[1]["params"]["areas"] == "FLUSA,CAUSA"
+    
+    def test_optional_parameters_handling(self, ofsc_instance):
+        """Test that optional parameters are handled correctly"""
+        
+        mock_response_data = {"items": []}
+        
+        with patch('requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = mock_response_data
+            mock_get.return_value = mock_response
+            
+            # Minimal call - only dates
+            ofsc_instance.capacity.getQuota(dates=["2025-06-25"])
+            
+            call_args = mock_get.call_args
+            params = call_args[1]["params"]
+            
+            # Should only have dates
+            assert "dates" in params
+            assert "areas" not in params
+            assert "categories" not in params
+            assert "aggregateResults" not in params

--- a/uv.lock
+++ b/uv.lock
@@ -213,7 +213,7 @@ wheels = [
 
 [[package]]
 name = "ofsc"
-version = "2.12.3"
+version = "2.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
  ## Summary
  This PR adds comprehensive capacity management functionality to pyOFSC, including:
  - New `OFSCapacity` module for capacity and quota operations
  - Support for both `getAvailableCapacity` and `getQuota` endpoints
  - Flexible parameter handling with CsvList support
  - Generic internal converter function using type inspection

  ## Major Changes

  ### 1. New Capacity Module (`ofsc/capacity.py`)
  - **`getAvailableCapacity()`**: Get available capacity with individual parameters
    - Supports list, CSV string, and CsvList inputs for areas, dates, categories
    - Consistent with `getQuota` signature pattern
  - **`getQuota()`**: Get quota information with flexible parameters
    - Boolean parameters automatically converted to lowercase strings
    - All string array parameters support multiple input formats
  - **`_convert_model_to_api_params()`**: Internal generic converter using inspection
    - Automatically detects CsvList and boolean fields
    - No hardcoded field names - works with any Pydantic model
    - DRY implementation shared by both public methods

  ### 2. Enhanced Models (`ofsc/models.py`)
  - **`CsvList`**: Utility model for comma-separated string lists
    - `from_list()` and `to_list()` conversion methods
    - Automatic conversion in field validators
  - **`CapacityRequest`**: Updated to use CsvList fields with validators
  - **`GetQuotaRequest`**: Request model with comprehensive parameters
  - **`GetQuotaResponse`** and **`QuotaAreaItem`**: Response models for quota data
  - All models support flexible input formats (list[str], str, CsvList)

  ### 3. Module Integration
  - Capacity module integrated as top-level API alongside core and metadata
  - Access via `ofsc_instance.capacity.getAvailableCapacity()` and `ofsc_instance.capacity.getQuota()`

  ### 4. Comprehensive Test Suite
  - **30+ mocked tests** covering all functionality
  - **19+ integration tests** for real server validation
  - **Real server responses** captured for consistent mocking
  - Tests for all input formats and edge cases
  - Performance tests included

  ## API Examples

  ```python
  # Get available capacity
  response = ofsc.capacity.getAvailableCapacity(
      dates=["2025-06-25", "2025-06-26"],
      areas=["FLUSA", "CAUSA"],
      categories=["EST", "RES"]
  )

  # Get quota information  
  response = ofsc.capacity.getQuota(
      dates="2025-06-25",
      areas=["FLUSA", "CAUSA"],
      aggregateResults=True,
      categoryLevel=False
  )

  Breaking Changes

  - getAvailableCapacity signature changed from accepting CapacityRequest object to individual parameters
  - This aligns with the getQuota pattern for consistency

  Testing

  - All tests passing (30 mocked, 19 integration)
  - Tested with real OFSC server using FLUSA/CAUSA areas
  - Performance validated with week-long date ranges

  The branch `69-add-capacity-endpoints` contains all the work we've done, including:
  - The initial capacity module implementation
  - The getQuota function
  - The updated getAvailableCapacity signature
  - The generic `_convert_model_to_api_params()` internal function
  - Comprehensive tests for everything

