### PR TITLE
Add delete activity endpoint

### DIFF
--- a/ofsc/core.py
+++ b/ofsc/core.py
@@ -48,6 +48,14 @@ class OFSCore(OFSApi):
         response = requests.patch(url, headers=self.headers, data=data)
         return response
 
+    @wrap_return(response_type=OBJ_RESPONSE, expected=[204])
+    def delete_activity(self, activity_id):
+        url = urljoin(
+            self.baseUrl, "/rest/ofscCore/v1/activities/{}".format(activity_id)
+        )
+        response = requests.delete(url, headers=self.headers)
+        return response
+
     # 202107 Added ssearch
     @wrap_return(response_type=OBJ_RESPONSE, expected=[200])
     def search_activities(self, params):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ofsc"
-version = "2.14.1"
+version = "2.15.0"
 description = "Python wrapper for Oracle Field Service API"
 authors = [{ name = "Borja Toron", email = "borja.toron@gmail.com" }]
 requires-python = "~=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <4"
 
 [[package]]
@@ -213,7 +213,7 @@ wheels = [
 
 [[package]]
 name = "ofsc"
-version = "2.14.1"
+version = "2.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary
Implements DELETE /rest/ofscCore/v1/activities/{activityId} endpoint to delete activities from Oracle Field Service Cloud.

## Changes
- Added `delete_activity()` method in `ofsc/core.py:51-57`
- Returns 204 No Content on successful deletion
- Follows existing decorator pattern with `@wrap_return`
- Added comprehensive tests in `tests/core/test_activities.py`:
  - `test_delete_activity_error`: validates 404 for non-existent activities
  - `test_delete_activity_success`: validates successful deletion of pending FLUSA activity
- Bumped version to 2.15.0 in `pyproject.toml`

## API Documentation
https://docs.oracle.com/en/cloud/saas/field-service/cxfsc/op-rest-ofsccore-v1-activities-activityid-delete.html

## Testing
All tests pass successfully:
- Error handling test validates 404 response for non-existent activities
- Success test deletes a real pending activity and confirms deletion

Resolves #75