### PR TITLE
fix: make tag creation idempotent in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           TAG="v${{ steps.version.outputs.version }}"
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin "$TAG"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping creation"
+          else
+            git tag -a "$TAG" -m "Release $TAG"
+            git push origin "$TAG"
+          fi
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4


### PR DESCRIPTION
## Summary
- Makes the "Create and push tag" step idempotent so workflow re-runs succeed when the tag already exists
- Fixes the case where the first run failed on PyPI publish (trusted publisher mismatch) and re-running failed because `v2.24.3` was already tagged

## Behavior
- If tag already exists → logs a skip message and continues to build + publish
- If tag does not exist → creates and pushes it as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)