### PR TITLE
Fix Pydantic deprecations and update dependencies to latest versions

### DIFF
--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -1,6 +1,6 @@
 # OFSC API Endpoints Reference
 
-**Version:** 2.25.0
+**Version:** 2.26.0
 **Last Updated:** 2026-03-05
 
 This document provides a comprehensive reference of all Oracle Field Service Cloud (OFSC) API endpoints and their implementation status in pyOFSC.

--- a/ofsc/models/metadata.py
+++ b/ofsc/models/metadata.py
@@ -543,7 +543,7 @@ class InventoryType(BaseModel):
     quantityPrecision: Optional[int] = 0
     unitOfMeasurement: Optional[str] = None
     links: Optional[list[Link]] = None
-    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+    model_config = ConfigDict(extra="ignore", validate_by_name=True, validate_by_alias=True)
 
 
 class InventoryTypeList(RootModel[list[InventoryType]]):

--- a/ofsc/models/resources.py
+++ b/ofsc/models/resources.py
@@ -94,14 +94,14 @@ class Recurrence(BaseModel):
     weekDays: Optional[list[str]] = None
 
     @model_validator(mode="after")
-    def check_week_days(cls, values):
-        if values.recurrenceType == RecurrenceType.weekly and not values.weekDays:
+    def check_week_days(self):
+        if self.recurrenceType == RecurrenceType.weekly and not self.weekDays:
             raise ValueError("weekDays is required for weekly recurrence")
-        if values.recurrenceType == RecurrenceType.yearly and not values.dayFrom:
+        if self.recurrenceType == RecurrenceType.yearly and not self.dayFrom:
             raise ValueError("dayFrom is required for yearly recurrence")
-        if values.recurrenceType == RecurrenceType.yearly and not values.dayTo:
+        if self.recurrenceType == RecurrenceType.yearly and not self.dayTo:
             raise ValueError("dayTo is required for yearly recurrence")
-        return values
+        return self
 
 
 class CalendarViewItemRecordType(str, Enum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ofsc"
-version = "2.25.0"
+version = "2.26.0"
 description = "Python wrapper for Oracle Field Service API"
 authors = [{ name = "Borja Toron", email = "borja.toron@gmail.com" }]
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -385,11 +385,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -885,9 +885,9 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "ofsc"
-version = "2.25.0"
+version = "2.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
This pull request updates the OFSC Python wrapper to version 2.26.0 and includes improvements to model validation logic and configuration. The changes primarily focus on enhancing data model validation and updating versioning information.

Version and documentation updates:

* Bumped the package version from 2.25.0 to 2.26.0 in both `pyproject.toml` and the API endpoints documentation (`docs/ENDPOINTS.md`). [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-ce4853e42781a90db46ba89020c2c33659de3b25cfa99662d507f6dae884d47bL3-R3)

Model validation improvements:

* Updated the `Recurrence` model's `check_week_days` validator to use instance attributes (`self`) instead of the previous classmethod-style (`cls` and `values`), ensuring that validation logic is more idiomatic and robust.
* Enhanced the `InventoryType` model configuration by enabling both `validate_by_name` and `validate_by_alias` in `model_config`, improving compatibility with different field naming conventions.