### PR TITLE
Allow null property GUI values

### DIFF
--- a/ofsc/models/metadata.py
+++ b/ofsc/models/metadata.py
@@ -829,6 +829,8 @@ class Property(BaseModel):
     @field_validator("gui")
     @classmethod
     def gui_match(cls, v):
+        if v is None:
+            return v
         if v not in [
             "text",
             "checkbox",

--- a/tests/metadata/test_properties.py
+++ b/tests/metadata/test_properties.py
@@ -38,6 +38,20 @@ def test_get_properties(instance, demo_data):
     assert response["items"][0]["label"] == "ITEM_NUMBER"
 
 
+def test_property_accepts_explicit_null_gui():
+    property_obj = Property.model_validate(
+        {
+            "label": "foo",
+            "name": "Foo",
+            "type": "string",
+            "gui": None,
+            "translations": [{"language": "en", "name": "Foo"}],
+        }
+    )
+
+    assert property_obj.gui is None
+
+
 @pytest.mark.serial
 @pytest.mark.uses_real_data
 def test_create_replace_property(instance: OFSC, faker):


### PR DESCRIPTION
## Summary
- allow explicit `gui: null` payloads to validate as omitted GUI values
- add a regression test for `Property.model_validate` with `gui` set to `None`

Fixes #169

## Verification
- `.venv/bin/python -m pytest tests/metadata/test_properties.py::test_property_accepts_explicit_null_gui -q`
- `.venv/bin/python -m ruff check --force-exclude ofsc/models/metadata.py tests/metadata/test_properties.py`
- `.venv/bin/python -m ruff check ofsc/models/metadata.py`