### PR TITLE
fix: accept string bulk update warning messages

### DIFF
--- a/ofsc/models/__init__.py
+++ b/ofsc/models/__init__.py
@@ -325,7 +325,7 @@ class BulkUpdateError(BaseModel):
 
 class BulkUpdateWarning(BaseModel):
     code: Optional[int] = None
-    message: Optional[int] = None
+    message: Optional[str] = None
 
 
 class BulkUpdateResult(BaseModel):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -8,6 +8,7 @@ from ofsc.common import OBJ_RESPONSE
 from ofsc.models import (
     ActivityType,
     ActivityTypeGroup,
+    BulkUpdateResponse,
     CapacityArea,
     CapacityAreaListResponse,
     CapacityCategoryListResponse,
@@ -23,6 +24,26 @@ from ofsc.models import (
     WorkskillList,
     WorkskillListResponse,
 )
+
+
+def test_bulk_update_response_accepts_string_warning_message():
+    raw = {
+        "results": [
+            {
+                "activityKeys": {"activityId": 4225, "apptNumber": "0010a000019oDas"},
+                "operationsPerformed": ["updateProperties", "updatePosition"],
+                "warnings": [
+                    {"code": 1, "message": "Activity moved to a non-scheduled bucket"},
+                ],
+            },
+        ],
+    }
+
+    response = BulkUpdateResponse.model_validate(raw)
+
+    warning = response.results[0].warnings[0]
+    assert warning.code == 1
+    assert warning.message == "Activity moved to a non-scheduled bucket"
 
 
 def test_translation_model_base():


### PR DESCRIPTION
## Summary
- Change `BulkUpdateWarning.message` from `Optional[int]` to `Optional[str]` so OFS warning text validates correctly.
- Add a no-network regression test for a `BulkUpdateResponse` carrying a string warning message.

Fixes #178.

## Validation
- `uv run --group dev pytest tests/test_model.py::test_bulk_update_response_accepts_string_warning_message -q`
- `uv run --group dev ruff check ofsc/models/__init__.py tests/test_model.py`
- `uv run --group dev ruff format --check ofsc/models/__init__.py tests/test_model.py`
- `git diff --check`
